### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,4 +1,6 @@
 name: linter
+permissions:
+  contents: read
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/dogecoin/security/code-scanning/3](https://github.com/roseteromeo56-cb-id/dogecoin/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs read operations (e.g., checking translations and subtree integrity), the minimal required permission is `contents: read`. This permission will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, ensuring no unnecessary write permissions are granted.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
