### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/dogecoin/security/code-scanning/2](https://github.com/roseteromeo56-cb-id/dogecoin/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow primarily involves building, testing, and uploading artifacts, it does not appear to require any write permissions. We will set `contents: read` as the minimal starting point. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended modifications.

The `permissions` block will be added at the top level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
